### PR TITLE
fix(ci): fast-forward pull before push in publish workflow

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -166,6 +166,7 @@ jobs:
             echo "ℹ️ No changes to commit (version already up-to-date)"
           else
             git commit -m "chore(${SKILL_NAME}): ${BUMP_TYPE} version bump to ${VERSION} [skip ci]"
+            git pull origin ${{ github.ref_name }} --ff
             git push origin HEAD:${{ github.ref_name }}
             echo "✅ Version changes committed and pushed"
           fi

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -166,7 +166,7 @@ jobs:
             echo "ℹ️ No changes to commit (version already up-to-date)"
           else
             git commit -m "chore(${SKILL_NAME}): ${BUMP_TYPE} version bump to ${VERSION} [skip ci]"
-            git pull origin ${{ github.ref_name }} --ff
+            git pull origin ${{ github.ref_name }} --ff-only
             git push origin HEAD:${{ github.ref_name }}
             echo "✅ Version changes committed and pushed"
           fi

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -31,11 +31,13 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
         run: |
           # Validate bump type (workflow-specific validation)
-          if [[ ! "${{ inputs.bump_type }}" =~ ^(major|minor|patch)$ ]]; then
+          if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
             echo "❌ Error: bump_type must be 'major', 'minor', or 'patch'"
-            echo "Provided: ${{ inputs.bump_type }}"
+            echo "Provided: $BUMP_TYPE"
             exit 1
           fi
 
@@ -48,11 +50,13 @@ jobs:
           bun-version: latest
 
       - name: Validate skill structure
+        env:
+          SKILL_NAME: ${{ inputs.skill_name }}
         run: |
-          echo "🔍 Validating skill: ${{ inputs.skill_name }}"
+          echo "🔍 Validating skill: $SKILL_NAME"
 
           # Get JSON output
-          RESULT=$(bunx @plaited/development-skills validate-skill "skills/${{ inputs.skill_name }}" --json)
+          RESULT=$(bunx @plaited/development-skills validate-skill "skills/$SKILL_NAME" --json)
 
           # Pretty print results
           echo "$RESULT" | jq .
@@ -62,7 +66,7 @@ jobs:
 
           if [ "$IS_VALID" != "true" ]; then
             echo ""
-            echo "❌ Skill validation failed for: ${{ inputs.skill_name }}"
+            echo "❌ Skill validation failed for: $SKILL_NAME"
             ERRORS=$(echo "$RESULT" | jq -r '.[0].errors | join(", ")')
             echo "Errors: $ERRORS"
             exit 1
@@ -155,18 +159,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit version changes
+        env:
+          VERSION: ${{ steps.bump-version.outputs.version }}
+          SKILL_NAME: ${{ inputs.skill_name }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION="${{ steps.bump-version.outputs.version }}"
-          SKILL_NAME="${{ inputs.skill_name }}"
-          BUMP_TYPE="${{ inputs.bump_type }}"
-
           git add "skills/${SKILL_NAME}/SKILL.md"
 
           if git diff --staged --quiet; then
             echo "ℹ️ No changes to commit (version already up-to-date)"
           else
             git commit -m "chore(${SKILL_NAME}): ${BUMP_TYPE} version bump to ${VERSION} [skip ci]"
-            git pull origin ${{ github.ref_name }} --ff-only
-            git push origin HEAD:${{ github.ref_name }}
+            git pull origin "$REF_NAME" --ff-only
+            git push origin "HEAD:$REF_NAME"
             echo "✅ Version changes committed and pushed"
           fi


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` checks out the **workflow trigger SHA**, not the current branch HEAD
- When chained `publish-*` jobs each push a version bump commit, later jobs have a stale base and fail with a non-fast-forward rejection on push
- Adds `git pull origin <branch> --ff` after the version bump commit, before the push — ensures each job is on top of whatever the previous jobs have pushed

## Test plan

- [ ] Trigger `publish.yml` with 2+ skills set to `patch` — verify all jobs succeed and each version bump commit lands cleanly on top of the previous

🤖 Generated with [Claude Code](https://claude.com/claude-code)