### PR TITLE
fix(ci): use --rebase not --ff-only when pulling before push

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -171,7 +171,7 @@ jobs:
             echo "ℹ️ No changes to commit (version already up-to-date)"
           else
             git commit -m "chore(${SKILL_NAME}): ${BUMP_TYPE} version bump to ${VERSION} [skip ci]"
-            git pull origin "$REF_NAME" --ff-only
+            git pull origin "$REF_NAME" --rebase
             git push origin "HEAD:$REF_NAME"
             echo "✅ Version changes committed and pushed"
           fi

--- a/skills/ydc-claude-agent-sdk-integration/SKILL.md
+++ b/skills/ydc-claude-agent-sdk-integration/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read Write Edit Bash(pip:install) Bash(npm:install) Bash(bun:add)
 metadata:
   author: youdotcom-oss
   category: sdk-integration
-  version: 1.2.1
+  version: 1.2.2
   keywords: claude,anthropic,claude-agent-sdk,agent-sdk,mcp,you.com,integration,http-mcp,web-search,python,typescript
 ---
 

--- a/skills/youdotcom-cli/SKILL.md
+++ b/skills/youdotcom-cli/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: youdotcom-cli
-description: |
-  Web search with livecrawl (search+extract) and content extraction for bash agents using You.com's @youdotcom-oss/api CLI.
-  - MANDATORY TRIGGERS: You.com, youdotcom, YDC, @youdotcom-oss/api, web search CLI, livecrawl
-  - Use when: web search needed, content extraction, URL crawling, real-time web data
+description: >
+  Web search with livecrawl (search+extract) and content extraction for bash
+  agents using You.com's @youdotcom-oss/api CLI.
+
+  - MANDATORY TRIGGERS: You.com, youdotcom, YDC, @youdotcom-oss/api, web search
+  CLI, livecrawl
+
+  - Use when: web search needed, content extraction, URL crawling, real-time web
+  data
 license: MIT
 compatibility: Requires Bun 1.3+ or Node.js 18+, and access to the internet
-allowed-tools: Bash(bunx:@youdotcom-oss/api) Bash(npx:@youdotcom-oss/api) Bash(bunx:ydc) Bash(npx:ydc) Bash(jq:*)
+allowed-tools: Bash(bunx:@youdotcom-oss/api) Bash(npx:@youdotcom-oss/api)
+  Bash(bunx:ydc) Bash(npx:ydc) Bash(jq:*)
 metadata:
   author: youdotcom-oss
-  version: "2.0.6"
+  version: 2.0.7
   category: web-search-tools
   keywords: you.com,bash,cli,ai-agents,web-search,content-extraction,livecrawl,claude-code,codex,cursor
 ---


### PR DESCRIPTION
## Summary

- Fixes continuing non-fast-forward push failures in chained `publish-*` jobs
- `--ff-only` fails after `git commit` because local now has a version bump commit **and** remote has advanced (previous job pushed) — these are diverged histories, not a simple fast-forward case
- `--rebase` is correct: replays the local version bump commit on top of whatever previous jobs pushed, producing a linear history before pushing

## How the sequence works with `--rebase`

1. Job checks out trigger SHA (commit A)
2. Job bumps version and commits locally (A → B)
3. `git pull --rebase`: fast-forwards local base to remote's latest (A → C), then replays B on top (A → C → B')
4. `git push` succeeds cleanly

## Test plan

- [ ] Trigger `publish.yml` with 2+ skills set to `patch` — verify all jobs complete and each version bump lands as a clean commit on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)