### PR TITLE
Add .claude-plugin/plugin.json for marketplace compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-skills",
+  "version": "1.0.0",
+  "description": "You.com agent skills for web search, research with citations, and content extraction. Guided integrations for Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, crewAI, LangChain, Microsoft Teams.ai, direct REST API, and bash CLI.",
+  "author": {
+    "name": "You.com",
+    "email": "support@you.com",
+    "url": "https://you.com"
+  },
+  "keywords": [
+    "you.com",
+    "web-search",
+    "research",
+    "content-extraction",
+    "mcp",
+    "ai-sdk",
+    "claude-agent-sdk",
+    "openai",
+    "crewai",
+    "langchain",
+    "teams-ai"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/youdotcom-oss/agent-skills",
+  "homepage": "https://you.com"
+}


### PR DESCRIPTION
## Summary

Adds the `.claude-plugin/plugin.json` manifest file required for Claude Code marketplace distribution.

Without this file, the plugin:
- Cannot be discovered or installed via `claude plugin install`
- Fails automated CI review on the marketplace staging pipeline (P1.29 check)
- Has no formal metadata (name, version, description, author)

The plugin content itself is excellent — 8 well-documented integration skills with comprehensive code templates, security guidance, and test assets. This manifest is the only structural piece missing for marketplace eligibility.

## Changes

- **New file:** `.claude-plugin/plugin.json` with standard fields (name, version, description, author, keywords, license, repository, homepage)

## Validation

- `claude plugin validate` — PASS
- Plugin structure smoke test — PASS
- JSON schema valid
- All required fields present (name, version, description)

## References

- [Claude Code Plugin Format](https://docs.anthropic.com/en/docs/claude-code/plugins)
- Example from SonarQube plugin: [plugin.json](https://github.com/SonarSource/sonarqube-agent-plugins/blob/main/.claude-plugin/plugin.json)