### PR TITLE
fix: unquote biome glob so shell expands it on CI

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: plugins/openclaw-youdotcom
 
       - name: Lint
-        run: bunx biome check "plugins/openclaw-youdotcom/*.ts"
+        run: bunx biome check plugins/openclaw-youdotcom/*.ts
 
       - name: Test
         run: bun test

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -81,6 +81,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit version bump
+        if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ steps.bump-version.outputs.version }}
           BUMP_TYPE: ${{ inputs.bump_type }}


### PR DESCRIPTION
The quoted glob `"plugins/openclaw-youdotcom/*.ts"` prevents bash from expanding the wildcard, causing Biome to receive a literal `*.ts` path that doesn't exist. Unquoting lets the shell expand the glob before passing the filenames to Biome.

Verified with a dry run: https://github.com/youdotcom-oss/agent-skills/actions/runs/24391927578