### PR TITLE
ci: support release publish-only runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       base_ref:
-        description: "Base ref for release planning"
+        description: "Base ref for release planning; reuse the same base when publishing a previously bumped release"
         required: false
         default: HEAD~1
       droid_advice:
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: false
       publish_artifacts:
-        description: "Publish npm, PyPI, and ClawHub artifacts after applying versions"
+        description: "Publish npm, PyPI, and ClawHub artifacts; with apply_versions=false, publish the current workflow ref"
         required: false
         type: boolean
         default: false
@@ -99,8 +99,8 @@ jobs:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
 
   apply:
-    name: Apply release plan
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_versions }}
+    name: Prepare release commit
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.apply_versions || inputs.publish_artifacts) }}
     needs: plan
     runs-on: ubuntu-latest
     outputs:
@@ -115,50 +115,61 @@ jobs:
           fetch-depth: 0
 
       - name: Download release plan
+        if: ${{ inputs.apply_versions }}
         uses: actions/download-artifact@v8
         with:
           name: release-plan
 
       - name: Setup Bun
+        if: ${{ inputs.apply_versions }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Setup uv
+        if: ${{ inputs.apply_versions }}
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies
+        if: ${{ inputs.apply_versions }}
         run: bun install --frozen-lockfile
 
       - name: Apply release plan
+        if: ${{ inputs.apply_versions }}
         run: bun scripts/semver-release.ts apply --plan release-plan.json
 
       - name: Validate release changes
+        if: ${{ inputs.apply_versions }}
         run: |
           bun run build
           bun run check
           bun run test
 
-      - name: Commit version changes
+      - name: Resolve release commit
         id: commit
         env:
+          APPLY_VERSIONS: ${{ inputs.apply_versions }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add skills packages .plugin .claude-plugin .codex-plugin .cursor-plugin .kimi-plugin .agents/plugins .github/plugin
-          if git diff --staged --quiet; then
-            echo "No version changes to commit"
+          if [[ "${APPLY_VERSIONS}" == "true" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add skills packages .plugin .claude-plugin .codex-plugin .cursor-plugin .kimi-plugin .agents/plugins .github/plugin
+            if git diff --staged --quiet; then
+              echo "No version changes to commit"
+            else
+              git commit -m "chore(release): apply semantic release plan [skip ci]"
+              git pull origin "$REF_NAME" --rebase
+              git push origin "HEAD:$REF_NAME"
+            fi
           else
-            git commit -m "chore(release): apply semantic release plan [skip ci]"
-            git pull origin "$REF_NAME" --rebase
-            git push origin "HEAD:$REF_NAME"
+            echo "Publishing current workflow ref without applying version changes"
           fi
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   publish-npm:
     name: Publish npm packages
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_versions && inputs.publish_artifacts && needs.plan.outputs.has_npm == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_npm == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     environment: npm
@@ -211,7 +222,7 @@ jobs:
 
   publish-pypi:
     name: Publish PyPI packages
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_versions && inputs.publish_artifacts && needs.plan.outputs.has_pypi == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_pypi == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     environment: pypi
@@ -251,7 +262,7 @@ jobs:
 
   publish-clawhub:
     name: Publish ClawHub package
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_versions && inputs.publish_artifacts && needs.plan.outputs.has_clawhub == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_clawhub == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- allow the release workflow to publish artifacts without re-applying version bumps
- make the release commit resolver run for either version application or publish-only runs
- keep apply/validate/commit steps conditional on `apply_versions=true`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("/Users/edward/Workspace/agent-skills/.github/workflows/release.yml"); puts "release.yml parsed"'`
- `actionlint /Users/edward/Workspace/agent-skills/.github/workflows/release.yml`
- `bunx clawhub package publish "youdotcom-oss/agent-skills@main" --source-path packages/openclaw --family bundle-plugin --owner youdotcom-oss --name you --version "" --source-commit "" --dry-run --json`