### PR TITLE
fix: skip deleted skills in release plans

### DIFF
--- a/scripts/semver-release.ts
+++ b/scripts/semver-release.ts
@@ -140,6 +140,7 @@ const createReleasePlan = async (baseRef: string): Promise<ReleasePlan> => {
   const changes = await readChangedPaths(baseRef)
   const statuses = await readChangedStatuses(baseRef)
   const addedPaths = new Set(statuses.filter((item) => item.status.startsWith('A')).map((item) => item.path))
+  const deletedPaths = new Set(statuses.filter((item) => item.status.startsWith('D')).map((item) => item.path))
   const headRef = (await $`git -C ${defaultRepoRoot} rev-parse --short HEAD`.text()).trim()
   const plan: ReleasePlan = {
     schemaVersion: 1,
@@ -159,6 +160,10 @@ const createReleasePlan = async (baseRef: string): Promise<ReleasePlan> => {
   for (const path of changes) {
     const skillMatch = /^skills\/([^/]+)\//.exec(path)
     if (skillMatch?.[1]) {
+      if (deletedPaths.has(path)) {
+        continue
+      }
+
       const { bump, rationale } = await changedSkillBump({ baseRef, path, isAdded: addedPaths.has(path) })
       plan.units.skills[skillMatch[1]] = updateReleaseUnit(plan.units.skills[skillMatch[1]], bump, path, rationale)
       plan.units.plugins.you = updateReleaseUnit(plan.units.plugins.you, bump, path, `skill ${skillMatch[1]} changed`)
@@ -370,6 +375,10 @@ export const createVersionUpdates = async ({ repoRoot, planPath }: { repoRoot: s
 
   for (const [skillName, unit] of Object.entries(plan.units.skills)) {
     if (unit.bump !== 'none') {
+      if (!(await Bun.file(resolve(repoRoot, `skills/${skillName}/SKILL.md`)).exists())) {
+        continue
+      }
+
       updates.push(await bumpSkillVersion({ repoRoot, skillName, bump: unit.bump }))
     }
   }

--- a/scripts/tests/semver-release.spec.ts
+++ b/scripts/tests/semver-release.spec.ts
@@ -86,6 +86,42 @@ describe('semver release', () => {
     }
   })
 
+  test('skips missing skills when applying a release plan', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'agent-skills-release-'))
+
+    try {
+      await writeFile(
+        join(repoRoot, 'plan.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          baseRef: 'HEAD~1',
+          headRef: 'HEAD',
+          generatedAt: '2026-07-22T00:00:00.000Z',
+          changes: ['skills/deleted-skill/SKILL.md'],
+          units: {
+            skills: {
+              'deleted-skill': {
+                bump: 'minor',
+                paths: ['skills/deleted-skill/SKILL.md'],
+                rationale: ['skill activation or MCP contract changed'],
+              },
+            },
+            plugins: {},
+            npm: {},
+            pypi: {},
+            clawhub: {},
+          },
+        }),
+      )
+
+      const updates = await createVersionUpdates({ repoRoot, planPath: 'plan.json' })
+
+      expect(updates).toEqual([])
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true })
+    }
+  })
+
   test('bumps Hermes PyPI package and plugin versions together', async () => {
     const repoRoot = await mkdtemp(join(tmpdir(), 'agent-skills-release-'))
 


### PR DESCRIPTION
## Summary
- skip deleted root skill paths when generating release plans
- make release-plan application tolerate missing skill files from older artifacts
- add regression coverage for missing skills during version update creation

## Validation
- `bun test /Users/edward/Workspace/agent-skills/scripts/tests/semver-release.spec.ts`
- `bun /Users/edward/Workspace/agent-skills/scripts/semver-release.ts plan --base 4712250ae8e5ce3095cad3b43b62b33608888863 --out /tmp/agent-skills-fixed-release-plan.json`
- `bun run check:types`
- `bun run check:ts scripts/semver-release.ts scripts/tests/semver-release.spec.ts`

The version-bump-only run failed before this fix because the plan included deleted skills such as `skills/teams-anthropic-integration/SKILL.md`, which no longer exist on `main`.