### PR TITLE
ci: format release version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,10 @@ jobs:
 
       - name: Apply release plan
         if: ${{ inputs.apply_versions }}
-        run: bun scripts/semver-release.ts apply --plan release-plan.json
+        run: |
+          bun scripts/semver-release.ts apply --plan release-plan.json
+          rm release-plan.json
+          bun run check:write
 
       - name: Validate release changes
         if: ${{ inputs.apply_versions }}


### PR DESCRIPTION
## Summary
- run the repo formatter after applying release-plan version bumps
- remove the downloaded release-plan artifact before validation so Biome does not check it as a workspace file

## Validation
- `actionlint /Users/edward/Workspace/agent-skills/.github/workflows/release.yml`
- `bun test /Users/edward/Workspace/agent-skills/scripts/tests/semver-release.spec.ts`
- `bun run check:types`

The latest version-bump-only run applied the plan, then failed validation because generated JSON files needed formatting.