### PR TITLE
ci: fix release publish retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,6 @@ jobs:
 
       - name: Publish to ClawHub
         env:
-          BRANCH: ${{ github.ref_name }}
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '.version' packages/openclaw/package.json)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,21 @@ on:
         required: false
         type: boolean
         default: false
+      publish_npm:
+        description: "Publish changed npm packages when publish_artifacts is enabled"
+        required: false
+        type: boolean
+        default: true
+      publish_pypi:
+        description: "Publish changed PyPI packages when publish_artifacts is enabled"
+        required: false
+        type: boolean
+        default: true
+      publish_clawhub:
+        description: "Publish changed ClawHub packages when publish_artifacts is enabled"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -172,7 +187,7 @@ jobs:
 
   publish-npm:
     name: Publish npm packages
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_npm == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && inputs.publish_npm && needs.plan.outputs.has_npm == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     environment: npm
@@ -219,13 +234,13 @@ jobs:
             package="${entry%%=*}"
             directory="${entry#*=}"
             if jq -e --arg package "$package" '(.units.npm[$package].bump // "none") != "none"' release-plan.json >/dev/null; then
-              npm publish --provenance --access public "$directory"
+              npm publish --provenance --access public "./$directory"
             fi
           done
 
   publish-pypi:
     name: Publish PyPI packages
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_pypi == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && inputs.publish_pypi && needs.plan.outputs.has_pypi == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     environment: pypi
@@ -265,7 +280,7 @@ jobs:
 
   publish-clawhub:
     name: Publish ClawHub package
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && needs.plan.outputs.has_clawhub == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_artifacts && inputs.publish_clawhub && needs.plan.outputs.has_clawhub == 'true' }}
     needs: [plan, apply]
     runs-on: ubuntu-latest
     steps:
@@ -292,11 +307,17 @@ jobs:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '.version' packages/openclaw/package.json)
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          CLAWHUB_PACKAGE_DIR="$(mktemp -d)/openclaw"
+          cp -R packages/openclaw "${CLAWHUB_PACKAGE_DIR}"
+          jq '.name = "you"' "${CLAWHUB_PACKAGE_DIR}/package.json" > "${CLAWHUB_PACKAGE_DIR}/package.json.tmp"
+          mv "${CLAWHUB_PACKAGE_DIR}/package.json.tmp" "${CLAWHUB_PACKAGE_DIR}/package.json"
           bunx clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
-          bunx clawhub package publish "youdotcom-oss/agent-skills@${BRANCH}" \
+          bunx clawhub package publish "${CLAWHUB_PACKAGE_DIR}" \
             --source-path packages/openclaw \
+            --source-repo youdotcom-oss/agent-skills \
             --family bundle-plugin \
             --owner youdotcom-oss \
             --name you \
             --version "${VERSION}" \
-            --source-commit "$(git rev-parse HEAD)"
+            --source-commit "${SOURCE_COMMIT}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,9 @@ The GitHub Actions UI runs **Semantic Release** manually:
 1. Open **Actions** -> **Semantic Release** -> **Run workflow**.
 2. First run with `apply_versions=false` and `publish_artifacts=false`; inspect the `release-plan` artifact.
 3. Set `base_ref` to the intended comparison point. `HEAD~1` only sees the last commit; an older base may bump every changed skill, plugin, npm package, PyPI package, and ClawHub package since that ref.
-4. Run again with `apply_versions=true` to commit version bumps.
-5. Run with `publish_artifacts=true` only when ready to publish npm, PyPI, and ClawHub artifacts.
+4. Run again with `apply_versions=true` and `publish_artifacts=false` to commit version bumps.
+5. After the version-bump commit lands on the branch, run publish-only with `apply_versions=false` and `publish_artifacts=true`.
+6. If a registry already succeeded and a retry should skip it, disable the matching publish toggle: `publish_npm`, `publish_pypi`, or `publish_clawhub`.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- add per-registry publish toggles for npm, PyPI, and ClawHub so partial publish failures can be retried safely
- publish npm package directories with explicit relative paths
- publish ClawHub from a temporary package copy whose package.json name matches the public `you` package while preserving source metadata
- update AGENTS.md release workflow instructions for version-bump, publish-only, and retry flows

## Validation
- `actionlint /Users/edward/Workspace/agent-skills/.github/workflows/release.yml`
- ClawHub dry-run publish from a temporary renamed package copy
- `npm pack ./packages/opencode --dry-run`
- `npm pack ./packages/pi --dry-run`
- `npm pack ./packages/openclaw --dry-run`

## Publish status from failed run
- PyPI succeeded: `hermes-youdotcom@0.1.0`
- npm did not publish: registry still shows `opencode@0.0.0`, `pi@0.0.0`, `openclaw@1.0.2`
- ClawHub failed before publishing due package name mismatch