### PR TITLE
docs: clarify You.com payment guidance

### DIFF
--- a/skills/you-discover/SKILL.md
+++ b/skills/you-discover/SKILL.md
@@ -36,6 +36,8 @@ Use this skill while planning how to integrate You.com with an agent SDK, IDE, a
 5. Compare discovery results and docs, then recommend the smallest integration path.
 6. If no first-class integration fits, recommend a small direct API script or thin MCP bridge rather than reimplementing catalog crawling in the skill.
 
+When planning paid direct API or MCP integrations, keep payment protocol guidance endpoint-specific: search and contents use x402 for keyless paid retries, while research and finance research can use MPP or x402.
+
 ## Planning loop
 
 Use `you-discover` as part of the integration planning loop, not as a one-time preflight check:

--- a/skills/you-finance/SKILL.md
+++ b/skills/you-finance/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: you-finance
-description: Route finance questions to an existing local script, a new You.com Finance Research API call, or an MCP fallback.
+description: Route finance questions to an existing local script, a new You.com Finance Research API call, or an MCP payment-aware fallback.
 license: MIT
-compatibility: Requires network access and either the You.com Finance Research API with `YDC_API_KEY`, or a You.com MCP client that can tolerate long finance responses.
+compatibility: Requires network access and either the You.com Finance Research API with `YDC_API_KEY` or MPP/x402 payment support, or a You.com MCP client that can tolerate long finance responses and keyless MPP/x402 payment challenges.
 metadata:
-  mcp_servers: '{"you-docs":{"url":"https://you.com/docs/_mcp/server","auth":"none","tools":["searchDocs"]},"you-finance-fallback":{"url":"https://api.you.com/mcp?tools=you-finance","auth":"YDC_API_KEY OAuth","tools":["you-finance"]}}'
+  mcp_servers: '{"you-docs":{"url":"https://you.com/docs/_mcp/server","auth":"none","tools":["searchDocs"]},"you-finance-fallback":{"url":"https://api.you.com/mcp?tools=you-finance","auth":"YDC_API_KEY OAuth MPP/x402","tools":["you-finance"]}}'
   author: youdotcom-oss
   version: 0.1.0
   category: finance
@@ -17,12 +17,12 @@ Use this skill to decide how a local code agent should answer finance-specific q
 
 ## Prerequisites
 
-For API scripts, `YDC_API_KEY` must be available.
+For API scripts, use `YDC_API_KEY` when available or an MPP/x402-capable HTTP client for keyless paid Finance Research API calls.
 
 For MCP fallback, the You.com finance MCP server must be installed and connected with a client that can tolerate long finance responses:
 
 - Server URL: `https://api.you.com/mcp?tools=you-finance`
-- Auth: either `YDC_API_KEY` bearer auth or OAuth login into the server. For bearer auth, set `Authorization: Bearer ${YDC_API_KEY}` in the host MCP client.
+- Auth: either `YDC_API_KEY` bearer auth, OAuth login into the server, or an MPP/x402-aware MCP client. For bearer auth, set `Authorization: Bearer ${YDC_API_KEY}` in the host MCP client.
 - Required tool: `you-finance`
 
 ## Local code-agent workflow
@@ -30,14 +30,16 @@ For MCP fallback, the You.com finance MCP server must be installed and connected
 Before answering, choose the lightest path that fits the task:
 
 - If an existing local finance script exists, reuse it. Look in `scripts/`, package scripts, and the current working directory.
-- If `YDC_API_KEY` is available and no reusable script exists, write a small script or direct HTTP request to the Finance Research API.
-- Use these API request headers: `X-API-Key: ${YDC_API_KEY}` and `User-Agent: SKILL/(@youdotcom-oss/agent-skills you-finance)`.
+- If `YDC_API_KEY` or an MPP/x402-capable HTTP client is available and no reusable script exists, write a small script or direct HTTP request to the Finance Research API.
+- With `YDC_API_KEY`, use these API request headers: `X-API-Key: ${YDC_API_KEY}` and `User-Agent: SKILL/(@youdotcom-oss/agent-skills you-finance)`.
+- With MPP/x402, expect Finance Research API pricing by `research_effort`; retry `402 payment-required` only through a payment-capable client or library.
 - Before coding or updating a script, query the You.com Docs MCP server, usually through `searchDocs`, for current API details. Use a targeted query such as `Finance Research API v1 finance_research research_effort`.
 - If Docs MCP is unavailable, use the canonical page: https://you.com/docs/api-reference/finance-research/v1-finance_research
-- If direct API scripts are not practical because OAuth is required, and `you-finance` is present in an MCP client that can tolerate long response times, use the MCP fallback.
+- If direct API scripts are not practical because OAuth or MCP-hosted payment handling is required, and `you-finance` is present in an MCP client that can tolerate long response times, use the MCP fallback.
 - Prefer a dedicated `you-finance` server profile when using MCP and the host exposes server profiles. The expected remote MCP config is `https://api.you.com/mcp?tools=you-finance`.
-- If neither API access nor `you-finance` is available, ask the user to provide `YDC_API_KEY` for API access or install/enable the You.com finance MCP server profile.
-- `you-finance` supports You.com auth via `YDC_API_KEY` bearer auth or OAuth.
+- Finance Research API and `you-finance` can use either MPP or x402 when the client supports payment challenges. If the MCP client receives a `402 payment-required` challenge, let the client pay externally and retry with payment headers. Do not handle wallets or signing in this skill.
+- If neither API access nor `you-finance` is available, ask the user to provide `YDC_API_KEY`, install/enable the You.com finance MCP server profile, or use an MPP/x402-capable client.
+- `you-finance` supports You.com auth via `YDC_API_KEY` bearer auth, OAuth, or MCP payment-header pass-through.
 
 ## When to use
 

--- a/skills/you-free/SKILL.md
+++ b/skills/you-free/SKILL.md
@@ -23,7 +23,7 @@ The free You.com MCP server profile must be installed and connected before using
 - Auth: none. Do not require `YDC_API_KEY` or OAuth.
 - Required tool: `you-search`
 
-If the task needs URL content extraction, cited research synthesis, finance, or livecrawl full-content search, use the authenticated `you-web`, `you-research`, or `you-finance` skills instead.
+If the task needs URL content extraction, cited research synthesis, finance, or livecrawl full-content search, use `you-web`, `you-research`, or `you-finance` instead.
 
 ## MCP server
 
@@ -39,13 +39,15 @@ Before using this skill, check the MCP tools available in the current agent envi
 - If `you-search` is missing, ask the user to install or enable the You.com free MCP server profile.
 - The free profile does not require You.com auth via `YDC_API_KEY` or OAuth.
 
+If an x402-aware MCP client receives an HTTP `402` with a `payment-required` header, treat it as a payment challenge, not a tool failure. Let the MCP client handle external payment and retry with `Authorization: Payment ...`, `x-payment`, or `payment-signature` headers when supported.
+
 Do not use `livecrawl=web` with this skill. Do not use `you-contents`, `you-research`, or `you-finance`.
 
 ## Tool selection
 
 - Use `you-search` for simple current lookup, source discovery, and search-result based answers.
 - If the user provides URLs, asks for synthesized cited research, or needs finance-specific data, this skill cannot satisfy the request.
-- Ask the user to enable an authenticated You.com MCP profile or use the appropriate You.com skill for those tasks.
+- Ask the user to enable an authenticated or x402-capable You.com MCP profile, or use the appropriate You.com skill for those tasks.
 
 ## Safety
 

--- a/skills/you-research/SKILL.md
+++ b/skills/you-research/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: you-research
-description: Route research tasks between a cost-conscious agentic search workflow, You.com Research API scripts, and managed you-research MCP fallback.
-compatibility: Requires network access and either You.com MCP tools with `YDC_API_KEY` or OAuth, or the You.com Research API with `YDC_API_KEY`.
+description: Route research tasks between a cost-conscious agentic search workflow, You.com Research API scripts, and managed or payment-aware MCP fallback.
+compatibility: Requires network access and either You.com MCP tools with `YDC_API_KEY`, OAuth, or payment support, or the You.com Research API with `YDC_API_KEY` or an MPP/x402-capable client.
 license: MIT
 metadata:
-  mcp_servers: '{"you-docs":{"url":"https://you.com/docs/_mcp/server","auth":"none","tools":["searchDocs"]},"you-research-base":{"url":"https://api.you.com/mcp?tools=you-search,you-contents","auth":"YDC_API_KEY OAuth","tools":["you-search","you-contents"],"avoidTools":["you-research"]}}'
+  mcp_servers: '{"you-docs":{"url":"https://you.com/docs/_mcp/server","auth":"none","tools":["searchDocs"]},"you-research-base":{"url":"https://api.you.com/mcp?tools=you-search,you-contents","auth":"YDC_API_KEY OAuth x402","tools":["you-search","you-contents"],"avoidTools":["you-research"]}}'
   author: youdotcom-oss
   version: 0.1.0
   category: research
@@ -19,10 +19,13 @@ Use this skill to choose the right You.com research path for the user's goal: ag
 
 For API scripts:
 
-- `YDC_API_KEY` must be available.
-- Use these API request headers: `X-API-Key: ${YDC_API_KEY}` and `User-Agent: SKILL/(@youdotcom-oss/agent-skills you-research)`.
+- Use `YDC_API_KEY` when available, or an MPP/x402-capable HTTP client for keyless paid Research API calls.
+- With `YDC_API_KEY`, use these API request headers: `X-API-Key: ${YDC_API_KEY}` and `User-Agent: SKILL/(@youdotcom-oss/agent-skills you-research)`.
+- With MPP/x402, expect Research API pricing by `research_effort` and at least a 1 cent charge; confirm the user expects a paid managed research request before sending it.
 
-For the agent-led workflow, use the `you-research-base` MCP profile with `you-search` and `you-contents` when available. See the [agent-led deep-search workflow](references/agent-led-deep-search.md) for setup and workflow details.
+For the agent-led workflow, use the `you-research-base` MCP profile with `you-search` and `you-contents` when available. Those tools and their REST endpoints should use x402 for keyless paid retries, not MPP. See the [agent-led deep-search workflow](references/agent-led-deep-search.md) for setup and workflow details.
+
+MPP/x402-aware MCP or HTTP clients may receive HTTP `402` payment challenges from You.com tools and endpoints, then retry with payment headers. Use MPP/x402 for managed Research API calls where appropriate. Let the host client handle external payment and retry; do not add wallet signing logic to this skill.
 
 ## Research API scripts
 
@@ -40,13 +43,13 @@ If Docs MCP is unavailable, use the canonical pages:
 - https://you.com/docs/api-reference/research/v1-research-task
 - https://you.com/docs/api-reference/research/v1-research-task-stream
 
-Keep the script aligned with the docs returned at runtime and include the API request headers listed above.
+Keep the script aligned with the docs returned at runtime and include the auth or payment headers listed above. If the user wants keyless MPP/x402 direct HTTP usage for Research API, verify current payment guidance in Docs MCP first, then handle `402 payment-required` as a challenge and retry only through a payment-capable client or library. Do not apply MPP guidance to plain search or contents REST calls; those should use x402 only.
 
 ## Decision Tree
 
 - User is cost-conscious or wants to develop/fine-tune a research skill -> follow the [agent-led deep-search workflow](references/agent-led-deep-search.md).
 - User asks for You.com managed API output, structured output, source controls, background tasks, or `deep`/`exhaustive`/`frontier` research -> write a script against the Research API.
-- User needs OAuth and direct API scripts are not practical -> use managed `you-research` MCP only if the MCP client supports the expected response time.
+- User needs OAuth or MPP/x402 payment handling and direct API scripts are not practical -> use MCP only if the MCP client supports the expected response time and payment flow.
 - Simple lookup -> use `you-research-base` `you-search` once, answer directly.
 - URL provided -> use `you-research-base` `you-contents` on those URLs.
 - Everything else -> use the base agent-led workflow.

--- a/skills/you-research/references/agent-led-deep-search.md
+++ b/skills/you-research/references/agent-led-deep-search.md
@@ -20,7 +20,7 @@ You are a deep research agent. Answer complex, multi-step research questions by 
 Use the focused You.com MCP server profile when the host supports MCP:
 
 - Server URL: `https://api.you.com/mcp?tools=you-search,you-contents`
-- Auth: either `YDC_API_KEY` bearer auth or OAuth login into the server
+- Auth: either `YDC_API_KEY` bearer auth, OAuth login into the server, or an x402-aware MCP client that can process payment challenges
 - Required tools: `you-search` and `you-contents`
 - Avoid managed `you-research` for this base workflow; use it only as an OAuth or long-timeout fallback outside this workflow.
 
@@ -31,6 +31,8 @@ For bearer auth, configure the host MCP client with an authorization header equi
   "Authorization": "Bearer ${YDC_API_KEY}"
 }
 ```
+
+If the MCP client supports x402 and a search or contents tool call returns HTTP `402` with a `payment-required` header, treat it as a payment challenge. Let the client pay externally and retry through MCP with `Authorization: Payment ...`, `x-payment`, or `payment-signature` headers. Do not use MPP for plain search or contents REST calls, and do not add wallet signing or settlement logic to the research skill itself.
 
 ### Decision tree
 

--- a/skills/you-web/SKILL.md
+++ b/skills/you-web/SKILL.md
@@ -49,7 +49,7 @@ Before using this skill, check the MCP tools available in the current agent envi
 - For `you-search`, `you-contents`, and the corresponding REST endpoints, use x402 payment challenges only.
 - If a search or contents tool call returns HTTP `402` with `payment-required`, let the MCP client handle payment externally and retry. Do not treat that response as a final answer.
 - Research and finance endpoints have broader MPP/x402 support; use the `you-research` or `you-finance` skill for those flows.
-- Account balance is private billing data; use `you-balance` only with an explicit `YDC_API_KEY`, not a keyless payment flow.
+- Account balance is private billing data; do not access balance endpoints through keyless payment flows.
 - Do not implement wallet signing or payment settlement inside this skill. Use the host MCP client's x402 flow.
 
 ## Tools

--- a/skills/you-web/SKILL.md
+++ b/skills/you-web/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: you-web
-description: Use You.com MCP tools for current web search, URL content extraction, and cited web synthesis.
-compatibility: Requires network access and a You.com MCP server authenticated with `YDC_API_KEY` or OAuth, exposing `you-search`, `you-contents`, and `you-research`.
+description: Use You.com MCP tools for current web search, URL content extraction, cited web synthesis, and x402-aware web access.
+compatibility: Requires network access and a You.com MCP server exposing `you-search`, `you-contents`, and `you-research`; use `YDC_API_KEY`, OAuth, or an x402-aware client for paid/keyless search and contents retries.
 license: MIT
 metadata:
-  mcp_servers: '{"you-web":{"url":"https://api.you.com/mcp","auth":"YDC_API_KEY OAuth","tools":["you-search","you-contents","you-research"]}}'
+  mcp_servers: '{"you-web":{"url":"https://api.you.com/mcp","auth":"YDC_API_KEY OAuth x402","tools":["you-search","you-contents","you-research"]}}'
   author: youdotcom-oss
   version: 0.1.0
   category: web-search
@@ -17,10 +17,10 @@ Use You.com MCP tools when the answer depends on current web information, source
 
 ## Prerequisites
 
-The authenticated You.com MCP server must be installed and connected before using this skill:
+The You.com MCP server must be installed and connected before using this skill:
 
 - Server URL: `https://api.you.com/mcp`
-- Auth: either `YDC_API_KEY` bearer auth or OAuth login into the server
+- Auth: either `YDC_API_KEY` bearer auth, OAuth login into the server, or an x402-aware MCP client that can process `402 payment-required` challenges
 - Required tools: `you-search`, `you-contents`, and `you-research`
 
 For bearer auth, configure the host MCP client with an authorization header equivalent to:
@@ -31,17 +31,26 @@ For bearer auth, configure the host MCP client with an authorization header equi
 }
 ```
 
-If auth is not available and the task only needs basic search, use the `you-free` skill instead.
+If auth is not available and the client is not x402-aware, use the `you-free` skill for basic search.
 
 ## MCP server
 
-Use the You.com MCP server at `https://api.you.com/mcp`. The server requires `YDC_API_KEY` bearer auth or OAuth login.
+Use the You.com MCP server at `https://api.you.com/mcp`. The normal setup is `YDC_API_KEY` bearer auth or OAuth login. x402-aware clients can receive upstream payment challenges and retry search or contents calls through MCP with payment headers.
 
 Before using this skill, check the MCP tools available in the current agent environment:
 
 - If `you-search`, `you-contents`, and `you-research` are available, use them directly.
-- If the server or required tools are missing, ask the user to install or enable the You.com MCP server with `YDC_API_KEY` or OAuth.
+- If the server or required tools are missing, ask the user to install or enable the You.com MCP server with `YDC_API_KEY`, OAuth, or an x402-capable client.
 - Do not invent MCP commands for the host. Use the host's installed MCP tool interface.
+
+## x402 payment behavior
+
+- The MCP server forwards payment retry headers upstream: `Authorization: Payment ...`, `x-payment`, and `payment-signature`.
+- For `you-search`, `you-contents`, and the corresponding REST endpoints, use x402 payment challenges only.
+- If a search or contents tool call returns HTTP `402` with `payment-required`, let the MCP client handle payment externally and retry. Do not treat that response as a final answer.
+- Research and finance endpoints have broader MPP/x402 support; use the `you-research` or `you-finance` skill for those flows.
+- Account balance is private billing data; use `you-balance` only with an explicit `YDC_API_KEY`, not a keyless payment flow.
+- Do not implement wallet signing or payment settlement inside this skill. Use the host MCP client's x402 flow.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- clarify x402-only guidance for search and contents flows
- document MPP/x402 support for research and finance research API paths
- add discovery guidance for endpoint-specific payment protocol selection

## Validation
- bun test tests/validate-skills.spec.ts
- bun run build
- bun run --cwd packages/pi test
- bun run --cwd packages/pi check:types