### PR TITLE
docs: clean up you-discover flow

### DIFF
--- a/skills/you-discover/SKILL.md
+++ b/skills/you-discover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: you-discover
-description: Route You.com integration planning through the you-discover MCP tool, AI Catalog entries, Docs MCP, and direct API options.
-compatibility: Requires network access. Prefer the standard You.com MCP server exposing `you-discover` and Docs MCP `searchDocs`; fall back to https://api.you.com/.well-known/ai-catalog.json.
+description: Route You.com integration planning through the you-discover MCP tool, Docs MCP, and direct API options.
+compatibility: Requires network access. Prefer the standard You.com MCP server exposing `you-discover` and Docs MCP `searchDocs`.
 license: MIT
 metadata:
   mcp_servers: '{"you-docs":{"url":"https://you.com/docs/_mcp/server","auth":"none","tools":["searchDocs"]},"you":{"url":"https://api.you.com/mcp","auth":"YDC_API_KEY OAuth","tools":["you-discover"],"resources":true,"prompts":true}}'
@@ -19,28 +19,22 @@ Use this skill while planning how to integrate You.com with an agent SDK, IDE, a
 
 1. Check whether the standard You.com MCP server exposes `you-discover` at `https://api.you.com/mcp`.
 2. Check whether the You.com Docs MCP tool `searchDocs` is available at `https://you.com/docs/_mcp/server`.
-3. If `you-discover` is missing, read `https://api.you.com/.well-known/ai-catalog.json` directly when possible. If the catalog is not published, unavailable, or incomplete, fall back to Docs MCP or docs pages.
+3. If `you-discover` is unavailable but Docs MCP is available, continue with docs-only planning and clearly state that catalog discovery was not available.
 4. If neither discovery nor docs access is available, ask the user to enable the standard You.com MCP server or Docs MCP before recommending install steps.
 
 ## Discovery workflow
 
 1. Restate the integration target, for example "Pi", "OpenCode", "LangChain", "Vercel AI SDK", "Claude", or "Cursor".
-2. Use `you-discover` to search You.com's AI Catalog, and any catalogs it links to when supported, for resources that match the target task.
+2. When available, use `you-discover` to search You.com's AI Catalog, and any catalogs it links to when supported, for resources that match the target task.
 3. Use `searchDocs` to verify official You.com docs for API References, MCP setup, Python SDK, auth, and install commands.
-4. If `you-discover` is unavailable, read the static AI Catalog at `https://api.you.com/.well-known/ai-catalog.json`. Look for entries whose type or description matches:
-   - MCP servers
-   - agent SDK guides
-   - IDE or coding-agent integrations
-   - Skills
-   - OpenAPI or SDK resources
-5. Compare discovery results and docs, then recommend the smallest integration path.
-6. If no first-class integration fits, recommend a small direct API script or thin MCP bridge rather than reimplementing catalog crawling in the skill.
+4. Compare available `you-discover` results and docs, then recommend the smallest integration path.
+5. If no first-class integration fits, recommend a small direct API script or thin MCP bridge rather than reimplementing catalog crawling in the skill.
 
 When planning paid direct API or MCP integrations, keep payment protocol guidance endpoint-specific: search and contents use x402 for keyless paid retries, while research and finance research can use MPP or x402.
 
 ## Planning loop
 
-Use `you-discover` as part of the integration planning loop, not as a one-time preflight check:
+Use `you-discover` and Docs MCP as part of the integration planning loop, not as a one-time preflight check:
 
 1. Discover candidate resources for the user's target, constraints, and host environment.
 2. Draft a plan that names the selected resource, why it fits, required auth, install path, and fallback.
@@ -51,7 +45,6 @@ Use `you-discover` as part of the integration planning loop, not as a one-time p
 
 Agentic Resource Discovery (ARD) is useful here because You.com publishes multiple agentic resources and may link to partner catalogs. ARD is discovery only: use it to choose a resource, then invoke that resource through MCP, an API, a skill, an SDK, or a plugin.
 
-- You.com catalog: `https://api.you.com/.well-known/ai-catalog.json`.
 - Discovery tool: `you-discover` on `https://api.you.com/mcp`.
 - Catalog entries can include MCP servers, SDK docs, Skills, OpenAPI specs, plugins, agents, and integration guides.
 - Linked catalogs can expand discovery beyond You.com-owned resources when the discovery tool supports them.


### PR DESCRIPTION
## Summary
- remove the static AI Catalog fallback from you-discover metadata and workflow
- clarify docs-only planning when you-discover is unavailable
- renumber and tighten the discovery workflow

## Tests
- bun test tests/validate-skills.spec.ts