### PR TITLE
docs: add x402 finance research example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,20 @@ Use you-discover to compare You.com MCP, Python SDK, and direct API options for 
 
 See each package README for host-specific details.
 
+## Examples
+
+Standalone runnable clients that show a You.com API surface end to end. They carry their own dependencies and are not part of the workspace build.
+
+| Example                                                                          | Shows                                                                                                          |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [`examples/x402-finance-research/`](./examples/x402-finance-research/README.md) | Keyless [x402](https://x402.org) payment: pay USDC on Base for a Finance Research report with no API key or account. |
+
 ## Repository Layout
 
 | Path                 | Purpose                                         |
 | -------------------- | ----------------------------------------------- |
 | `skills/`            | Shared You.com skills                           |
+| `examples/`          | Standalone runnable examples                    |
 | `.claude-plugin/`    | Claude Code plugin manifest                     |
 | `.cursor-plugin/`    | Cursor plugin manifest                          |
 | `.codex-plugin/`     | Codex and ChatGPT plugin manifest               |

--- a/biome.json
+++ b/biome.json
@@ -57,6 +57,16 @@
   },
   "overrides": [
     {
+      "includes": ["examples/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["scripts/**"],
       "linter": {
         "rules": {

--- a/examples/x402-finance-research/README.md
+++ b/examples/x402-finance-research/README.md
@@ -1,0 +1,95 @@
+# Pay an API $0.11 in USDC and get a research report back
+
+No API key. No account. No signup. Your agent hits an endpoint, gets `402 Payment
+Required`, pays with stablecoin, and gets the result — in about 100 seconds.
+
+This is [x402](https://x402.org) against the You.com Finance Research API, running on
+Base. The whole client is [~110 lines](./x402-you-research.js).
+
+```
+[1] POST /v1/finance_research (no payment)  ← HTTP 402 Payment Required
+      price   0.110000 USDC · exact / eip155:8453 · USD Coin
+[2] sign EIP-3009 authorization             (no gas — the payer sends no on-chain tx)
+      sig     0x9e5f8aae…  132 hex chars = 65-byte secp256k1
+[3] retry with payment attached             ← HTTP 202 · ✔ PAYMENT SETTLED success=true
+      tx      https://basescan.org/tx/0xa6d0e79d…
+[4] SIWX (CAIP-122) auth on the result URL  ← HTTP 202 (accepted)
+[5] report delivered                        11.2 KB · 15 sources · 103s
+```
+
+## Quickstart
+
+```bash
+cd examples/x402-finance-research
+npm install
+```
+
+**1. Make a wallet.** Any EOA works — this makes a fresh one:
+
+```js
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+const pk = generatePrivateKey()
+console.log(privateKeyToAccount(pk).address, pk)
+```
+
+**2. Fund it** with a couple of USDC on **Base**. You don't need ETH — the `exact`
+scheme signs an EIP-3009 authorization and a facilitator settles it, so the payer
+pays no gas.
+
+**3. Rehearse for free.** `DRY=1` signs the payment and stops before submitting it:
+
+```bash
+DRY=1 PRIVATE_KEY=0x... node x402-you-research.js "Should I buy NVDA?"
+```
+
+**4. Run it.**
+
+```bash
+PRIVATE_KEY=0x... node x402-you-research.js "Should I buy NVDA?"
+```
+
+`MAX_USDC` (default `0.15`) is a hard ceiling — the script throws before producing a
+signature if the price is above it. `EFFORT` is `standard` (~$0.055), `deep` (~$0.11),
+or `exhaustive`.
+
+## Gotchas
+
+Four things that will cost you an afternoon if nobody tells you:
+
+**`api.you.com` speaks x402 v2, not v1.** Requirements arrive in a `payment-required`
+response header, not the JSON body. The widely-referenced `x402-fetch@1.x` crashes on
+it with `Cannot read properties of undefined (reading 'map')`. Use `@x402/fetch@2.x`
+plus `@x402/evm`.
+
+**The result is async and gated by SIWX.** Paying returns a `jobId` and a `poll_url`;
+the report arrives 1–3 minutes later. That URL requires a
+[Sign-In-With-X](https://docs.x402.org/extensions/sign-in-with-x) (CAIP-122) signature
+proving the same wallet paid — sent base64-encoded in a `SIGN-IN-WITH-X` header.
+
+**The SIWX challenge comes back in a `401` JSON body**, not a `402` header — so the
+stock `wrapFetchWithSIWx` helper won't fire. Read `body['sign-in-with-x']` yourself.
+
+**You generate the `nonce` and `issuedAt`.** The server doesn't send them, and
+`createSIWxPayload` only copies fields through. Omit them and the payload fails schema
+validation. The nonce must be alphanumeric.
+
+## The payer must be a plain EOA
+
+The result endpoint currently advertises `type: "eip191"` with `signatureScheme: null` —
+plain `personal_sign` only. Smart-contract wallets that sign via ERC-1271/ERC-6492
+(Coinbase Base Account, most modern smart wallets) will pay successfully but then fail
+at the result-fetch step. Use a plain private-key account until smart-wallet signature
+verification ships.
+
+## Handle the key like a hot wallet
+
+The private key sits in plaintext wherever you put it. Fund it with what you intend to
+spend and nothing more, keep `MAX_USDC` tight, and never commit the file.
+
+## Related
+
+- [`you-finance`](../../skills/you-finance/SKILL.md) — the skill that routes finance
+  questions to this API, with `YDC_API_KEY` or keyless MPP/x402 payment.
+- [Finance Research API reference](https://you.com/docs/api-reference/finance-research/v1-finance_research)
+- [You.com API keys](https://you.com/platform/api-keys) if you would rather use a key
+  than a wallet.

--- a/examples/x402-finance-research/package.json
+++ b/examples/x402-finance-research/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@youdotcom-oss/example-x402-finance-research",
+  "description": "Keyless x402 client that pays USDC on Base for a You.com Finance Research report.",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "dependencies": {
+    "@x402/evm": "^2.21.0",
+    "@x402/extensions": "^2.21.0",
+    "@x402/fetch": "^2.21.0",
+    "viem": "^2.55.11"
+  }
+}

--- a/examples/x402-finance-research/x402-you-research.js
+++ b/examples/x402-finance-research/x402-you-research.js
@@ -83,8 +83,11 @@ async function siwxFetch(url) {
   const first = await fetch(url)
   if (first.status !== 401) return { res: first, body: await first.json().catch(() => null) }
 
-  const challenge = (await first.json())['sign-in-with-x']
+  // Not every 401 is a SIWX challenge — rate limits and proxy errors land here too.
+  const challenge = (await first.json().catch(() => null))?.['sign-in-with-x']
+  if (!challenge?.supportedChains) throw new Error('401 carried no sign-in-with-x challenge')
   const chain = challenge.supportedChains.find((c) => c.chainId === NETWORK)
+  if (!chain) throw new Error(`challenge offers no ${NETWORK} option`)
   if (chain.type !== 'eip191') throw new Error(`server wants ${chain.type}; this signs eip191`)
 
   // The server sends no nonce/issuedAt and createSIWxPayload only copies them
@@ -101,7 +104,11 @@ async function siwxFetch(url) {
   return { res, body: await res.json().catch(() => null) }
 }
 
-const pollUrl = new URL(job.poll_url, ORIGIN).toString()
+// poll_url is server-supplied and gets the SIWX signature, so it must stay on-origin:
+// an absolute URL would override the base and send proof-of-wallet to another host.
+if (!job.poll_url) throw new Error(`no poll_url in the response: ${JSON.stringify(job)}`)
+const pollUrl = new URL(job.poll_url, ORIGIN)
+if (pollUrl.origin !== ORIGIN) throw new Error(`poll_url points off-origin: ${pollUrl.origin}`)
 const started = Date.now()
 while (Date.now() - started < 300_000) {
   const { res, body } = await siwxFetch(pollUrl)
@@ -110,7 +117,12 @@ while (Date.now() - started < 300_000) {
     process.exit(1)
   }
   if (res.ok && body && body.status !== 'pending' && body.status !== 'running') {
-    console.log(`\n--- report (${body.output.sources.length} sources) ---\n`)
+    // Terminal but not successful — you already paid, so say why rather than crashing.
+    if (!body.output) {
+      console.error(`\njob ended as ${body.status}:`, body)
+      process.exit(1)
+    }
+    console.log(`\n--- report (${body.output.sources?.length ?? 0} sources) ---\n`)
     console.log(body.output.content)
     process.exit(0)
   }

--- a/examples/x402-finance-research/x402-you-research.js
+++ b/examples/x402-finance-research/x402-you-research.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+//
+// Buy a You.com finance research report with USDC on Base — no API key, no account.
+//
+//   npm install   (from this directory)
+//   PRIVATE_KEY=0x... node x402-you-research.js "Should I buy NVDA?"
+//
+//   DRY=1 signs the payment and stops before submitting it — free dress rehearsal.
+//
+// Flow: 402 Payment Required -> sign EIP-3009 -> settled on Base -> SIWX-authed result.
+//
+import { randomBytes } from 'node:crypto'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { ExactEvmScheme } from '@x402/evm'
+import { createSIWxPayload, encodeSIWxHeader } from '@x402/extensions'
+import { decodePaymentResponseHeader, wrapFetchWithPayment, x402Client } from '@x402/fetch'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const ENDPOINT = 'https://api.you.com/v1/finance_research'
+const ORIGIN = 'https://api.you.com'
+const NETWORK = 'eip155:8453' // Base mainnet
+const MAX_USDC = Number(process.env.MAX_USDC ?? '0.15') // hard spend ceiling
+const EFFORT = process.env.EFFORT ?? 'deep' // standard | deep | exhaustive
+const DRY = process.env.DRY === '1'
+
+const question = process.argv[2]
+if (!process.env.PRIVATE_KEY || !question) {
+  console.error('usage: PRIVATE_KEY=0x... node x402-you-research.js "your question"')
+  process.exit(1)
+}
+
+// The payer must be a plain EOA — see "Gotchas" in the README.
+const account = privateKeyToAccount(process.env.PRIVATE_KEY)
+
+// ── 1. Pay the 402 ──────────────────────────────────────────────────────────
+// Reject anything above the cap BEFORE a signature exists.
+const selectWithCap = (_version, requirements) => {
+  const chosen = requirements.find((r) => r.network === NETWORK && r.scheme === 'exact')
+  if (!chosen) throw new Error(`no exact/${NETWORK} option offered`)
+  const usdc = Number(chosen.amount) / 1e6
+  if (usdc > MAX_USDC) throw new Error(`price ${usdc} USDC exceeds cap ${MAX_USDC} — not signing`)
+  console.log(`price: ${usdc} USDC -> ${chosen.payTo}`)
+  return chosen
+}
+
+let calls = 0
+const tracingFetch = async (input, init) => {
+  // The paid retry is request #2. In DRY mode we stop it before it leaves.
+  if (DRY && ++calls > 1) {
+    const hdr = [...input.headers].find(([k]) => /^(x-)?payment(-signature)?$/i.test(k))
+    console.log(`DRY RUN — signed but not submitted\nheader: ${hdr?.[0]} (${hdr?.[1].length} B)`)
+    process.exit(0)
+  }
+  return fetch(input, init)
+}
+
+const client = new x402Client(selectWithCap).register(NETWORK, new ExactEvmScheme(account))
+const fetchWithPay = wrapFetchWithPayment(tracingFetch, client)
+
+console.log(`payer: ${account.address}`)
+const submit = await fetchWithPay(ENDPOINT, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ input: question, research_effort: EFFORT }),
+})
+const job = await submit.json()
+if (!submit.ok) {
+  console.error(`failed ${submit.status}:`, job)
+  process.exit(1)
+}
+
+const receipt = submit.headers.get('payment-response')
+if (receipt) {
+  const r = decodePaymentResponseHeader(receipt)
+  console.log(`settled: success=${r.success}\ntx: https://basescan.org/tx/${r.transaction}`)
+}
+console.log(`jobId: ${job.jobId}`)
+
+// ── 2. Fetch the result, proving you paid (SIWX / CAIP-122) ─────────────────
+// The result URL is gated by Sign-In-With-X. You.com returns the challenge in a
+// 401 JSON body (not a 402 header), so the stock wrapFetchWithSIWx doesn't apply.
+async function siwxFetch(url) {
+  const first = await fetch(url)
+  if (first.status !== 401) return { res: first, body: await first.json().catch(() => null) }
+
+  const challenge = (await first.json())['sign-in-with-x']
+  const chain = challenge.supportedChains.find((c) => c.chainId === NETWORK)
+  if (chain.type !== 'eip191') throw new Error(`server wants ${chain.type}; this signs eip191`)
+
+  // The server sends no nonce/issuedAt and createSIWxPayload only copies them
+  // through — so the client generates them.
+  const info = {
+    ...challenge.info,
+    chainId: NETWORK,
+    type: chain.type,
+    nonce: randomBytes(16).toString('hex'), // must be alphanumeric
+    issuedAt: new Date().toISOString(),
+  }
+  const payload = await createSIWxPayload(info, account)
+  const res = await fetch(url, { headers: { 'SIGN-IN-WITH-X': encodeSIWxHeader(payload) } })
+  return { res, body: await res.json().catch(() => null) }
+}
+
+const pollUrl = new URL(job.poll_url, ORIGIN).toString()
+const started = Date.now()
+while (Date.now() - started < 300_000) {
+  const { res, body } = await siwxFetch(pollUrl)
+  if (res.status === 401 || res.status === 403) {
+    console.error(`auth failed ${res.status}:`, body)
+    process.exit(1)
+  }
+  if (res.ok && body && body.status !== 'pending' && body.status !== 'running') {
+    console.log(`\n--- report (${body.output.sources.length} sources) ---\n`)
+    console.log(body.output.content)
+    process.exit(0)
+  }
+  process.stdout.write(`\rresearching… ${Math.round((Date.now() - started) / 1000)}s`)
+  await sleep(5000)
+}
+console.error('\ntimed out — the job may still finish; re-poll the same URL')
+process.exit(1)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  // `examples/` are standalone runnable snippets with their own dependencies, not part of the workspace build.
+  "exclude": ["examples"],
   "compilerOptions": {
     // Environment setup & latest features
     "lib": ["ESNext"],


### PR DESCRIPTION
Move the keyless x402 client from a gist into the repo as a standalone
runnable example. It pays USDC on Base for a You.com Finance Research
report with no API key or account, and covers the two undocumented parts
of the flow: x402 v2 payment requirements arriving in a response header,
and the SIWX (CAIP-122) challenge that gates the result URL arriving in a
401 JSON body.

- examples/ excluded from the root tsconfig; the example carries its own
  pinned dependencies and is not part of the workspace build
- biome override allows console in examples/, matching scripts/

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A1uN7nJmkPoq7NifTToX5G