### PR TITLE
docs: add Deep Code CLI to install table and platform list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo is for developers who want to:
 
 - add You.com MCP tools and skills to their coding agent quickly
 - use `you-discover` to find the right You.com API, MCP server, SDK, or docs path for an agentic project
-- package the same You.com skills for agent platforms such as Claude Code, Cursor, Codex, Copilot CLI, Kimi Code, OpenCode, OpenClaw, Pi, and Hermes
+- package the same You.com skills for agent platforms such as Claude Code, Cursor, Codex, Copilot CLI, Deep Code CLI, Kimi Code, OpenCode, OpenClaw, Pi, and Hermes
 
 ## Start Here
 
@@ -42,6 +42,7 @@ npx skills add youdotcom-oss/agent-skills --skill you-finance
 | GitHub Copilot CLI              | `copilot plugin marketplace add youdotcom-oss/agent-skills` then `copilot plugin install you@you-com` |
 | Codex                           | `codex plugin marketplace add youdotcom-oss/agent-skills --sparse .agents/plugins`                    |
 | Cursor                          | Install this repository from the Cursor plugin UI or CLI                                              |
+| Deep Code CLI                   | `npx skills add youdotcom-oss/agent-skills`                                                           |
 | Kimi Code                       | `/plugins install <repo url>`                                                                         |
 | OpenCode                        | `opencode plugin @youdotcom-oss/opencode`                                                             |
 | OpenClaw                        | `openclaw plugins install clawhub:you` or `openclaw plugins install npm:@youdotcom-oss/openclaw`      |


### PR DESCRIPTION
## What changed

Added Deep Code CLI to the README:

1. **Install table** — new row between Cursor and Kimi Code with the universal installer command `npx skills add youdotcom-oss/agent-skills`
2. **Intro paragraph** — added "Deep Code CLI" to the platform list

## Why

[Deep Code CLI](https://github.com/lessweb/deepcode-cli) is a 2.2k-star terminal AI coding agent tuned for DeepSeek. It has built-in Agent Skills support and scans `~/.agents/skills/` as one of its four skill scan roots, which means the universal `npx skills add` installer already works for it today.

Unlike Claude Code, Cursor, Codex, and Copilot CLI, Deep Code has no plugin marketplace or package install mechanism. Skills are discovered purely through directory scanning, so there is no manifest or package directory to add here. The only gap was discoverability: a Deep Code user visiting this README had no way to know their client is supported. This row closes that gap.

We are also opening [lessweb/deepcode-cli#317](https://github.com/lessweb/deepcode-cli/pull/317), which documents You.com MCP setup in the Deep Code CLI docs directly. The two PRs are complementary: this one makes our skills discoverable on our side, #317 makes our MCP server discoverable on their side.

## Validation

- `bun run check:ts` (Biome) — 38 files checked, no fixes needed
- `bun test tests/validate-skills.spec.ts` — 9 pass, 0 fail
- Table column alignment verified against existing rows
