### PR TITLE
feat: add Grok Build plugin manifest

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "you-com",
+  "description": "You.com Grok Build plugins for web search, research, finance, and integration discovery skills.",
+  "owner": {
+    "name": "You.com",
+    "email": "support@you.com"
+  },
+  "plugins": [
+    {
+      "name": "you",
+      "source": ".",
+      "description": "You.com skills for search, contents, research, finance, and integration discovery.",
+      "category": "productivity",
+      "version": "0.5.0"
+    }
+  ]
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "you",
+  "version": "0.5.0",
+  "description": "You.com skills for search, contents, research, finance, and integration discovery with MCP, ARD, API-key, OAuth, and MPP/x402 payment guidance.",
+  "author": {
+    "name": "You.com",
+    "email": "support@you.com",
+    "url": "https://you.com"
+  },
+  "homepage": "https://docs.you.com",
+  "repository": "https://github.com/youdotcom-oss/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "you.com",
+    "grok-build",
+    "agent-skills",
+    "mcp",
+    "web-search",
+    "content-extraction",
+    "research",
+    "finance",
+    "citations",
+    "ard",
+    "ai-catalog",
+    "x402",
+    "mpp"
+  ],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo is for developers who want to:
 
 - add You.com MCP tools and skills to their coding agent quickly
 - use `you-discover` to find the right You.com API, MCP server, SDK, or docs path for an agentic project
-- package the same You.com skills for agent platforms such as Claude Code, Cursor, Codex, Copilot CLI, Kimi Code, OpenCode, OpenClaw, Pi, and Hermes
+- package the same You.com skills for agent platforms such as Claude Code, Cursor, Codex, Copilot CLI, Kimi Code, Grok Build, OpenCode, OpenClaw, Pi, and Hermes
 
 ## Start Here
 
@@ -43,6 +43,7 @@ npx skills add youdotcom-oss/agent-skills --skill you-finance
 | Codex                           | `codex plugin marketplace add youdotcom-oss/agent-skills --sparse .agents/plugins`                    |
 | Cursor                          | Install this repository from the Cursor plugin UI or CLI                                              |
 | Kimi Code                       | `/plugins install <repo url>`                                                                         |
+| Grok Build                      | `grok plugin marketplace add youdotcom-oss/agent-skills` then `grok plugin install you --trust`       |
 | OpenCode                        | `opencode plugin @youdotcom-oss/opencode`                                                             |
 | OpenClaw                        | `openclaw plugins install clawhub:you` or `openclaw plugins install npm:@youdotcom-oss/openclaw`      |
 | Pi                              | `pi install npm:@youdotcom-oss/pi`                                                                    |
@@ -123,6 +124,7 @@ See each package README for host-specific details.
 | `.codex-plugin/`     | Codex and ChatGPT plugin manifest               |
 | `.plugin/`           | GitHub Copilot CLI plugin manifest              |
 | `.kimi-plugin/`      | Kimi Code plugin manifest                       |
+| `.grok-plugin/`      | Grok Build plugin manifest                      |
 | `packages/opencode/` | OpenCode package                                |
 | `packages/openclaw/` | OpenClaw package                                |
 | `packages/pi/`       | Pi package                                      |

--- a/scripts/semver-release.ts
+++ b/scripts/semver-release.ts
@@ -31,12 +31,14 @@ const pluginManifests = [
   '.codex-plugin/plugin.json',
   '.cursor-plugin/plugin.json',
   '.kimi-plugin/plugin.json',
+  '.grok-plugin/plugin.json',
 ]
 const pluginMarketplaces = [
   '.claude-plugin/marketplace.json',
   '.agents/plugins/marketplace.json',
   '.cursor-plugin/marketplace.json',
   '.github/plugin/marketplace.json',
+  '.grok-plugin/marketplace.json',
 ]
 const pluginReleasePaths = [...pluginManifests, ...pluginMarketplaces]
 const npmPackages = {

--- a/scripts/tests/semver-release.spec.ts
+++ b/scripts/tests/semver-release.spec.ts
@@ -14,6 +14,8 @@ describe('semver release', () => {
     expect(isPluginReleasePath('.cursor-plugin/marketplace.json')).toBe(true)
     expect(isPluginReleasePath('.plugin/plugin.json')).toBe(true)
     expect(isPluginReleasePath('.github/plugin/marketplace.json')).toBe(true)
+    expect(isPluginReleasePath('.grok-plugin/plugin.json')).toBe(true)
+    expect(isPluginReleasePath('.grok-plugin/marketplace.json')).toBe(true)
     expect(isPluginReleasePath('skills/you-web/SKILL.md')).toBe(false)
   })
 
@@ -51,6 +53,7 @@ describe('semver release', () => {
         '.cursor-plugin/plugin.json',
         '.plugin/plugin.json',
         '.kimi-plugin/plugin.json',
+        '.grok-plugin/plugin.json',
       ]) {
         await mkdir(dirname(join(repoRoot, path)), { recursive: true })
         await writeFile(join(repoRoot, path), `${JSON.stringify({ name: 'you', version: '1.2.3' })}\n`)
@@ -61,6 +64,7 @@ describe('semver release', () => {
         '.agents/plugins/marketplace.json',
         '.cursor-plugin/marketplace.json',
         '.github/plugin/marketplace.json',
+        '.grok-plugin/marketplace.json',
       ]) {
         await mkdir(dirname(join(repoRoot, path)), { recursive: true })
         await writeFile(
@@ -77,10 +81,12 @@ describe('semver release', () => {
       expect(updatedByPath.get('.cursor-plugin/plugin.json')?.version).toBe('1.2.4')
       expect(updatedByPath.get('.plugin/plugin.json')?.version).toBe('1.2.4')
       expect(updatedByPath.get('.kimi-plugin/plugin.json')?.version).toBe('1.2.4')
+      expect(updatedByPath.get('.grok-plugin/plugin.json')?.version).toBe('1.2.4')
       expect(updatedByPath.get('.claude-plugin/marketplace.json')?.plugins[0].version).toBe('1.2.4')
       expect(updatedByPath.get('.agents/plugins/marketplace.json')?.plugins[0].version).toBe('1.2.4')
       expect(updatedByPath.get('.cursor-plugin/marketplace.json')?.plugins[0].version).toBe('1.2.4')
       expect(updatedByPath.get('.github/plugin/marketplace.json')?.plugins[0].version).toBe('1.2.4')
+      expect(updatedByPath.get('.grok-plugin/marketplace.json')?.plugins[0].version).toBe('1.2.4')
     } finally {
       await rm(repoRoot, { force: true, recursive: true })
     }


### PR DESCRIPTION
Adds `.grok-plugin/` so You.com is installable in xAI's Grok Build as a native surface, and so the xAI plugin marketplace catalog has a manifest to point at.

## Why

Grok Build reads `.grok-plugin/marketplace.json` and `.grok-plugin/plugin.json`, and accepts the `.claude-plugin/` equivalents as a fallback ([plugins guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/09-plugins.md)). So this repo is *already* installable there today — but the native manifest is what the marketplace catalog expects, and it makes the supported surface explicit instead of incidental.

This unblocks the catalog submission to [`xai-org/plugin-marketplace`](https://github.com/xai-org/plugin-marketplace), which pins a commit SHA from this repo as a remote source.

## What's here

- `.grok-plugin/plugin.json` and `.grok-plugin/marketplace.json`, mirroring the existing per-surface manifests, version pegged at `0.5.0`.
- Both registered in `scripts/semver-release.ts` (`pluginManifests` / `pluginMarketplaces`) so releases bump them with the rest — without this they'd silently drift out of sync.
- `scripts/tests/semver-release.spec.ts` extended to cover them.
- README: surface list, install row (`grok plugin marketplace add …` / `grok plugin install you --trust`), and layout table.

## Deliberately not included

No `.mcp.json`. Per `AGENTS.md` — *"Do not inline MCP configs into shared manifests unless the host specifically requires it; users choose keyless, API-key, OAuth, MPP, or x402 setup by need."* Grok Build does support a plugin-level `.mcp.json`, so bundling the keyless `you-search` endpoint for a zero-config first run is a real option, but that changes behaviour for every surface reading the repo root and is a product call, not a packaging one. Raised separately on DX-803.

## Verification

- `bun test` — 28 pass, 1 fail; the failure is `Pi extension > … from real endpoints`, which also fails on a clean checkout of `main` (live-endpoint test, unrelated).
- `bun run check` — all checks passed (biome, tsc, ruff/mypy, format-package).